### PR TITLE
fix:  route table entry changed by ofp_vs

### DIFF
--- a/example/ofp_vs/ofp_vs_xmit.c
+++ b/example/ofp_vs/ofp_vs_xmit.c
@@ -45,8 +45,6 @@ static struct ofp_nh_entry *ip_vs_get_out_rt(struct rte_mbuf *skb,
         vrf = send_ctx ? send_ctx->vrf : 0;
         nh = ofp_get_next_hop(vrf, daddr, &flags);
         if (nh) {
-            if (!nh->gw)
-                nh->gw = daddr;
             IP_VS_DBG(12, "%s dst:"
                   PRINT_IP_FORMAT" gw:"
                   PRINT_IP_FORMAT


### PR DESCRIPTION
If the route tables entry's gateway is 0, ofp_vs will change the route table entry.
In my case, the route table as below:
> route
Destination        Gateway         Iface  Flags
0.0.0.0/0          192.168.10.1    fp0    gateway
10.1.0.0/24        0.0.0.0         fp1    net
10.1.0.1/32        0.0.0.0         fp1    local
192.168.10.0/24    0.0.0.0         fp0    net
192.168.10.253/32  0.0.0.0         fp0    local

After ofp_vs forwarded one request, the route table as below:
> route
Destination        Gateway         Iface  Flags
0.0.0.0/0          192.168.10.1    fp0    gateway
10.1.0.0/24        0.0.0.0         fp1    net
10.1.0.1/32        0.0.0.0         fp1    local
192.168.10.0/24    192.168.10.170  fp0    net
192.168.10.253/32  0.0.0.0         fp0    local